### PR TITLE
Log out on page click if token expired

### DIFF
--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
 import { useAuthContext } from '../hooks/useAuthContext';
-import UserMenu from './UserMenu';
+import { logOutIfTokenExpired } from '../utils/logOutIfTokenExpired';
+import UserMenu from './UserMenu'
 
 export default function Navbar(){
   const { user } = useAuthContext();
@@ -36,7 +37,7 @@ React.useEffect(() => {
 }, [user]);
 
     return (
-      <header className={user ? "header--blur" : ""}>
+      <header className={user ? "header--blur" : ""} onClick={user && logOutIfTokenExpired}>
         <div className="container">
           <h1 className={user ? "logged--in--logo" : "logo"}>
             <Link to="/">WorkoutMate</Link>

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -6,6 +6,7 @@ import { useAuthContext } from "../hooks/useAuthContext";
 import Pagination from '../components/Pagination';
 import { useSearch } from '../hooks/useSearch';
 import Search from '../components/Search';
+import { logOutIfTokenExpired } from '../utils/logOutIfTokenExpired';
 
 export default function Home() {
     const [addWorkoutForm, setAddWorkoutForm] = React.useState(false);
@@ -15,15 +16,6 @@ export default function Home() {
     const [page, setPage] = React.useState(0);
     const [pageSpread, setPageSpread] = React.useState([]);
     const [query, setQuery] = React.useState("");
-
-    React.useEffect(()=> {
-     const tokenExpires = JSON.parse(localStorage.getItem('user')).tokenExpires; 
-     const timeout = tokenExpires - Date.now();
-     setTimeout(()=> {
-       localStorage.removeItem("user");
-       window.location.reload(); 
-     }, timeout)
-    }, [])
 
     React.useEffect(() => {
       getItems(query, page);
@@ -67,12 +59,10 @@ export default function Home() {
       setQuery(e.target.value);
       setPage(0);
    }
-    return (
-      <div className="home--container">
-        {!user && <h3>Access denied.</h3>}
-        {user && (
-          <div className="home">
 
+    return (
+      <div className="home--container" onClick={logOutIfTokenExpired}>
+          <div className="home">
             <Search
               handleSearchChange={handleSearchChange}
               handleSearch={handleSearch}
@@ -138,7 +128,6 @@ export default function Home() {
               </p>
             </div>
           </div>
-        )}
       </div>
     );
 };

--- a/frontend/src/utils/logOutIfTokenExpired.js
+++ b/frontend/src/utils/logOutIfTokenExpired.js
@@ -1,0 +1,10 @@
+
+export const logOutIfTokenExpired = () => {
+  if(localStorage.getItem("user")){
+     const tokenExpires = JSON.parse(localStorage.getItem("user")).tokenExpires;
+   if (tokenExpires < Date.now()) {
+     localStorage.removeItem("user");
+     window.location.reload();
+    } 
+  }
+};


### PR DESCRIPTION
Instead of setting up automatic logout by setting timeout on every page load - which has shown to be unreliable when the window goes out of focus - a click event listener is set on the Home page and Navbar (only when user is logged in) that will fire logOutIfTokenExpires.