### PR TITLE
App crashing at user update fixed

### DIFF
--- a/backend/businessLogic/auth.js
+++ b/backend/businessLogic/auth.js
@@ -67,7 +67,9 @@ const updateUser = async (user, id, body) => {
   if (!user) {
     ApiError.notAuthorized("Not authorized");
   }
-  if (!body.username || (body.username && !body.username.trim())) return;
+  if ((!body.username || !body.username.trim()) && !body.profileImg) {
+    return await User.findById(id);
+  }
   if (
     body.username &&
     body.username.trim() &&
@@ -96,8 +98,7 @@ const updateUser = async (user, id, body) => {
     ApiError.badInput("Image too big - 1MB max");
   }
   const userUpdated = await User.update(id, body);
-  if (userUpdated) return userUpdated;
-  return;
+  return userUpdated;
 };
 
 const deleteUser = async (id) => {

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -43,32 +43,17 @@ module.exports.user_update_patch = async (req, res) => {
   const { id } = req.params;
   const token = req.headers.authorization.slice(7);
   const body = req.body;
-  const userUpdated = await updateUser(user, id, body);
-  if (userUpdated) {
-    res.status(200).json({
-      user: {
-        id: userUpdated._id,
-        email: userUpdated.email,
-        username: userUpdated.username,
-        profileImg: userUpdated.profileImg,
-        token: token,
-      },
-      success: "Profile updated.",
-    });
-    return;
-  } else {
-    res.status(200).json({
-      user: {
-        id: id,
-        email: user.email,
-        username: user.username,
-        profileImg: user.profileImg,
-        token: token,
-      },
-      success: "",
-    });
-    return;
-  }
+  const { email, username, profileImg } = await updateUser(user, id, body);
+  return res.status(200).json({
+    user: {
+      id,
+      email,
+      username,
+      profileImg,
+      token,
+    },
+    success: "Profile updated.",
+  });
 };
 
 module.exports.user_deletion = async (req, res) => {

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -21,18 +21,23 @@ export default function Navbar() {
   };
 
   useEffect(() => {
-    if (user) {
-      const username = localStorage.getItem("username");
-      if (!user.username && !username) {
-        const i = user.email.indexOf("@");
-        setUsername(`${user.email.slice(0, i)}`);
-      } else {
-        if (username) setUsername(username);
-        if (user.username && !username) setUsername(user.username);
-      }
-      const newImg = localStorage.getItem("newImg");
-      if (user.profileImg && !newImg) setProfileImg(user.profileImg);
-      if (newImg) setProfileImg(newImg);
+    if (!user) return;
+    const username = localStorage.getItem("username");
+    if (username) {
+      setUsername(username);
+    } else if (user.username) {
+      setUsername(user.username);
+    } else {
+      const i = user.email.indexOf("@");
+      setUsername(`${user.email.slice(0, i)}`);
+    }
+    const newImg = localStorage.getItem("newImg");
+    if (newImg) {
+      setProfileImg(newImg);
+    } else if (user.profileImg) {
+      setProfileImg(user.profileImg);
+    } else {
+      return;
     }
   }, [user]);
 
@@ -65,9 +70,7 @@ export default function Navbar() {
         {!user && (
           <div
             className="about--login--signup--nav"
-            onClick={() =>
-              dispatch({ type: "RESET_USER_STATE" })
-            }
+            onClick={() => dispatch({ type: "RESET_USER_STATE" })}
           >
             <Link to="/about" aria-label="about workout mate">
               <span className="about--btn">About</span>

--- a/frontend/src/hooks/useUpdateUser.js
+++ b/frontend/src/hooks/useUpdateUser.js
@@ -11,6 +11,7 @@ export const useUpdateUser = () => {
       dispatch({ type: "UPDATE_USER_FAIL", payload: "Not authorized" });
       return;
     }
+    const body = {};
     if (
       profileImg &&
       profileImg.match(/^data:image\/jpeg/) &&
@@ -32,6 +33,7 @@ export const useUpdateUser = () => {
         dispatch({ type: "RESET_USER_MESSAGE_STATE" });
       }, 5000);
     }
+    body.profileImg = profileImg;
     if (username && username.trim() && username.trim().length > 12) {
       dispatch({ type: "UPDATE_USER_FAIL", payload: "Too long username" });
       return;
@@ -44,10 +46,9 @@ export const useUpdateUser = () => {
       });
       return;
     }
-    const body = {
-      username: username,
-      profileImg: profileImg,
-    };
+    if (username && username.trim()) {
+      body.username = username;
+    }
     const response = await fetch(
       `${process.env.REACT_APP_API}/api/users/${user.id}`,
       {


### PR DESCRIPTION
The error was initially located at Navbar.js line 27 every time the update request was sent with a falsy username value.

If the username had already been updated once in the session  - i.e. the username made available in the localStorage  - the error would not occur and remain concealed for the duration of the session.

The root cause of the error was more-less a combination of 2 things:
1.  That the frontend logic allowed falsy username property value in the request body leading to updating the username value to null in the database;
2.  That the updateUser server business logic would not return the expected response body content (specifically username and email) if the request body did not contain username.

After the response is sent, the useUpdateUser hook will (try and) not set username item to localStorage (as it's not returned in the response body) and Navbar.js will attempt to extract it from the email (which is not available in the user state at this point because email wasn't sent in the response body either) and the app will crash.

The specific interventions are described in commit messages.

